### PR TITLE
Ship cleanup

### DIFF
--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -5,12 +5,12 @@ attr_reader :name, :length, :health
     @length = length
     @health = 3
   end
+  
+  def hit
+    @health -= 1
+  end
 
   def sunk?
     @health <= 0
-  end
-
-  def hit
-    @health -= 1
   end
 end

--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -3,7 +3,7 @@ attr_reader :name, :length, :health
   def initialize(name, length)
     @name = name
     @length = length
-    @health = 3
+    @health = length
   end
   
   def hit

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -32,12 +32,7 @@ RSpec.describe Ship do
     end
   end
   
-  describe "hit" do 
-    it 'has not sunk' do
-      expect(@cruiser.sunk?).to be false
-      expect(@submarine.sunk?).to be false
-    end
-
+  describe "hit" do
     it 'has taken a hit' do
       @cruiser.hit
       expect(@cruiser.health).to eq(2)
@@ -45,24 +40,23 @@ RSpec.describe Ship do
       @submarine.hit
       expect(@submarine.health).to eq(1)
     end
-
-    it 'can be sunk' do
-      @cruiser.hit
-      @cruiser.hit
-      @cruiser.hit
-      expect(@cruiser.sunk?).to eq(true)
-    end
   end
 
   describe 'sunk?' do 
     it 'has not sunk' do
       expect(@cruiser.sunk?).to be false
+      expect(@submarine.sunk?).to be false
     end
+    
     it 'can be sunk' do
       @cruiser.hit
       @cruiser.hit
       @cruiser.hit
       expect(@cruiser.sunk?).to eq(true)
+
+      @submarine.hit
+      @submarine.hit
+      expect(@submarine.sunk?).to eq(true)
     end
   end
 end

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Ship do
 
     it 'has length' do 
       expect(@cruiser.length).to eq(3)
+      expect(@submarine.length).to eq(2)
     end
 
     it 'has health' do

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe Ship do
     it 'has health' do
       expect(@cruiser.health).to eq(3)
     end
-
+  end
+  
+  describe "hit" do 
     it 'has not sunk' do
       expect(@cruiser.sunk?).to be false
     end
@@ -35,6 +37,18 @@ RSpec.describe Ship do
       expect(@cruiser.health).to eq(2)
     end
 
+    it 'can be sunk' do
+      @cruiser.hit
+      @cruiser.hit
+      @cruiser.hit
+      expect(@cruiser.sunk?).to eq(true)
+    end
+  end
+
+  describe 'sunk?' do 
+    it 'has not sunk' do
+      expect(@cruiser.sunk?).to be false
+    end
     it 'can be sunk' do
       @cruiser.hit
       @cruiser.hit

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -7,11 +7,13 @@ end
 RSpec.describe Ship do 
   before(:each) do 
     @cruiser = Ship.new("Cruiser", 3)
+    @submarine = Ship.new("Submarine", 2)
   end
 
   describe 'Initialize' do 
     it 'exists' do 
       expect(@cruiser).to be_an_instance_of(Ship)
+      expect(@submarine).to be_an_instance_of(Ship)
     end
     
     it 'has a name' do 

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe Ship do
     it 'has taken a hit' do
       @cruiser.hit
       expect(@cruiser.health).to eq(2)
+
+      @submarine.hit
+      expect(@submarine.health).to eq(1)
     end
 
     it 'can be sunk' do

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Ship do
     
     it 'has a name' do 
       expect(@cruiser.name).to eq ("Cruiser")
+      expect(@submarine.name).to eq("Submarine")
     end
 
     it 'has length' do 

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Ship do
   describe "hit" do 
     it 'has not sunk' do
       expect(@cruiser.sunk?).to be false
+      expect(@submarine.sunk?).to be false
     end
 
     it 'has taken a hit' do

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Ship do
 
     it 'has health' do
       expect(@cruiser.health).to eq(3)
+      expect(@submarine.health).to eq(2)
     end
   end
   


### PR DESCRIPTION
In this pull request I first organized our tests in describe blocks. I also for better readablility I switch the hit and sunk? methods. I felt that you would have to hit a ship before you sink a ship  but we can change it back if need be.  After that I added a submarine  ship to  before each statement and wrote tests for each method. The one method that failed was @health. Because we hard coded @health = 3 it was trying to give 3 as the submarines health. I changed @health to equal the length of the ship and got it passing. 